### PR TITLE
Remove joined_count column from usher_invitations table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Migration Guide
 
 **1. Dropping `table_name` Configuration:**
+
 The `table_name` configuration option has been removed. Usher now uses a fixed table name `usher_invitations` for the invitations table.
 
 If you were using a custom table name, you will need to rename the table to `usher_invitations`. You can do this as follows, by creating a new migration:
@@ -47,6 +48,7 @@ end
 Alternatively, you can delete the old Usher migrations and keep the latest migration that calls `Usher.Migration.migrate_to_version("v03")`, which will create all the necessary tables.
 
 **2. New Database Migration and Required Configuration:**
+
 For existing installations, create a new migration:
 ```bash
 mix ecto.gen.migration upgrade_usher_tables_v03
@@ -80,6 +82,7 @@ See the [configuration guide](guides/configuration.md) for more details.
 > ⚠️ There was a change in the migration system. The `migrate_to_latest/1` function is deprecated and will be removed in the next major release. Use `migrate_to_version/1` instead.
 
 **3. Removed `Usher.increment_joined_count/1` function:**
+
 The `Usher.increment_joined_count/1` function has been removed. Use the new `Usher.track_invitation_usage/5` function to track invitation usage instead:
 ```elixir
 {:ok, _} = Usher.track_invitation_usage(invitation, :user, user.id, :registered, metadata)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,6 @@ end
 Alternatively, you can delete the old Usher migrations and keep the latest migration that calls `Usher.Migration.migrate_to_version("v03")`, which will create all the necessary tables.
 
 **2. New Database Migration and Required Configuration:**
-
 For existing installations, create a new migration:
 ```bash
 mix ecto.gen.migration upgrade_usher_tables_v03
@@ -74,11 +73,17 @@ config :usher, Usher.Config,
     }
   }
 ```
-**Note: the new `valid_usage_entity_types` and `valid_usage_actions` options are required**.
+_Note: the new `valid_usage_entity_types` and `valid_usage_actions` options are **required**_
 
 See the [configuration guide](guides/configuration.md) for more details.
 
 > ⚠️ There was a change in the migration system. The `migrate_to_latest/1` function is deprecated and will be removed in the next major release. Use `migrate_to_version/1` instead.
+
+**3. Removed `Usher.increment_joined_count/1` function:**
+The `Usher.increment_joined_count/1` function has been removed. Use the new `Usher.track_invitation_usage/5` function to track invitation usage instead:
+```elixir
+{:ok, _} = Usher.track_invitation_usage(invitation, :user, user.id, :registered, metadata)
+```
 
 ### Added
 - **Invitation Usage Tracking System**: Introduced mapping between invitations and entity interactions

--- a/guides/advanced-usage.md
+++ b/guides/advanced-usage.md
@@ -201,8 +201,13 @@ defmodule MyApp.InvitationValidator do
   
   defp check_usage_limits(invitation, context) do
     max_uses = Map.get(context, :max_uses, 100)
+
+    invitation_usage_count =
+      invitation
+      |> Usher.list_invitation_usages_by_unique_entity(action: :joined)
+      |> Enum.count()
     
-    if invitation.joined_count >= max_uses do
+    if invitation_usage_count >= max_uses do
       {:error, :usage_limit_exceeded}
     else
       :ok

--- a/guides/invitation-usage-tracking.md
+++ b/guides/invitation-usage-tracking.md
@@ -209,18 +209,6 @@ defmodule MyApp.InvitationAnalytics do
 end
 ```
 
-## Legacy Tracking
-
-For simple use cases, you can still use the basic joined count:
-
-```elixir
-# Increment the simple counter
-{:ok, updated_invitation} = Usher.increment_joined_count(invitation)
-
-# Access the count
-count = invitation.joined_count
-```
-
 ## Error Handling
 
 Common error scenarios and handling:

--- a/guides/testing.md
+++ b/guides/testing.md
@@ -99,10 +99,5 @@ defmodule MyApp.InvitationTestHelpers do
   def invitation_url_for(invitation, base_url \\ "http://localhost:4000/signup") do
     Usher.invitation_url(invitation.token, base_url)
   end
-  
-  def assert_invitation_used(invitation, expected_count \\ 1) do
-    updated_invitation = Usher.get_invitation!(invitation.id)
-    assert updated_invitation.joined_count == expected_count
-  end
 end
 ```

--- a/lib/usher.ex
+++ b/lib/usher.ex
@@ -117,22 +117,6 @@ defmodule Usher do
   end
 
   @doc """
-  Increments the joined count for an invitation.
-
-  This is typically called when a user successfully registers using the invitation.
-
-  ## Examples
-
-      iex> Usher.increment_joined_count(invitation)
-      {:ok, %Usher.Invitation{joined_count: 1}}
-  """
-  def increment_joined_count(%Invitation{} = invitation) do
-    invitation
-    |> Invitation.increment_joined_count_changeset()
-    |> Config.repo().update()
-  end
-
-  @doc """
   Deletes an invitation.
 
   ## Examples

--- a/lib/usher/invitation.ex
+++ b/lib/usher/invitation.ex
@@ -14,7 +14,6 @@ defmodule Usher.Invitation do
           token: String.t(),
           name: String.t() | nil,
           expires_at: DateTime.t(),
-          joined_count: integer(),
           usages: [Usher.InvitationUsage.t()] | Ecto.Association.NotLoaded.t(),
           inserted_at: DateTime.t(),
           updated_at: DateTime.t()
@@ -27,7 +26,6 @@ defmodule Usher.Invitation do
     field(:token, :string)
     field(:name, :string)
     field(:expires_at, :utc_datetime)
-    field(:joined_count, :integer, default: 0)
 
     has_many(:usages, Usher.InvitationUsage, foreign_key: :invitation_id)
 
@@ -57,27 +55,11 @@ defmodule Usher.Invitation do
   """
   def changeset(invitation, attrs, opts \\ []) do
     invitation
-    |> cast(attrs, [:token, :name, :expires_at, :joined_count])
+    |> cast(attrs, [:token, :name, :expires_at])
     |> validate_required([:token, :expires_at])
     |> validate_name_if_required(opts)
-    |> validate_number(:joined_count, greater_than_or_equal_to: 0)
     |> validate_future_date(:expires_at)
     |> unique_constraint(:token, name: :usher_invitations_token_index)
-  end
-
-  @doc """
-  Changeset for incrementing the joined count.
-
-  This is for when a user successfully registers using the invitation.
-
-  ## Examples
-
-      iex> invitation = %Usher.Invitation{joined_count: 0}
-      iex> Usher.Invitation.increment_joined_count_changeset(invitation)
-      %Ecto.Changeset{changes: %{joined_count: 1}}
-  """
-  def increment_joined_count_changeset(invitation) do
-    change(invitation, joined_count: invitation.joined_count + 1)
   end
 
   defp validate_name_if_required(changeset, opts) do

--- a/lib/usher/migrations/v03.ex
+++ b/lib/usher/migrations/v03.ex
@@ -30,6 +30,10 @@ defmodule Usher.Migrations.V03 do
     create(index(:usher_invitation_usages, [:action]))
     create(index(:usher_invitation_usages, [:inserted_at]))
 
+    alter table(:usher_invitations, table_opts) do
+      remove(:joined_count)
+    end
+
     # Update version comment to track migration state
     prefix = Keyword.get(opts, :prefix, "public")
     execute("COMMENT ON TABLE #{prefix}.usher_invitations IS 'v03'")
@@ -37,5 +41,9 @@ defmodule Usher.Migrations.V03 do
 
   def down(opts) do
     drop(table(:usher_invitation_usages, opts))
+
+    alter table(:usher_invitations) do
+      add(:joined_count, :integer, default: 0, null: false)
+    end
   end
 end

--- a/test/support/test_fixtures.ex
+++ b/test/support/test_fixtures.ex
@@ -13,8 +13,7 @@ defmodule Usher.TestFixtures do
       Enum.into(attrs, %{
         token: "test_token_" <> (System.unique_integer([:positive]) |> to_string()),
         name: "Test Invitation",
-        expires_at: DateTime.add(DateTime.utc_now(), 7, :day),
-        joined_count: 0
+        expires_at: DateTime.add(DateTime.utc_now(), 7, :day)
       })
 
     %Invitation{}
@@ -44,18 +43,6 @@ defmodule Usher.TestFixtures do
     invitation
     |> Ecto.Changeset.change(expires_at: expires_at_in_the_past)
     |> Repo.update!()
-  end
-
-  @doc """
-  Generate a used invitation (with joined_count > 0).
-  """
-  def used_invitation_fixture(attrs \\ %{}) do
-    attrs =
-      Enum.into(attrs, %{
-        joined_count: 1
-      })
-
-    invitation_fixture(attrs)
   end
 
   @doc """

--- a/test/usher/invitation_test.exs
+++ b/test/usher/invitation_test.exs
@@ -45,26 +45,5 @@ defmodule Usher.InvitationTest do
       refute changeset.valid?
       assert "must be in the future" in errors_on(changeset).expires_at
     end
-
-    test "invalid changeset with negative joined_count" do
-      changeset =
-        Invitation.changeset(%Invitation{}, %{
-          token: "valid_token",
-          expires_at: DateTime.add(DateTime.utc_now(), 1, :day),
-          joined_count: -1
-        })
-
-      refute changeset.valid?
-      assert "must be greater than or equal to 0" in errors_on(changeset).joined_count
-    end
-  end
-
-  describe "increment_joined_count_changeset/1" do
-    test "increments joined count by 1" do
-      invitation = %Invitation{joined_count: 5}
-      changeset = Invitation.increment_joined_count_changeset(invitation)
-
-      assert changeset.changes.joined_count == 6
-    end
   end
 end

--- a/test/usher_test.exs
+++ b/test/usher_test.exs
@@ -8,7 +8,6 @@ defmodule UsherTest do
       assert invitation.token
       assert invitation.name == "Test Invitation"
       assert invitation.expires_at
-      assert invitation.joined_count == 0
       # Configured in `config.exs`
       assert String.length(invitation.token) == 16
     end
@@ -54,14 +53,6 @@ defmodule UsherTest do
       invitation = expired_invitation_fixture()
 
       assert {:error, :invitation_expired} = Usher.validate_invitation_token(invitation.token)
-    end
-  end
-
-  describe "increment_joined_count/1" do
-    test "increments the joined count" do
-      invitation = invitation_fixture(%{joined_count: 0})
-      assert {:ok, updated} = Usher.increment_joined_count(invitation)
-      assert updated.joined_count == 1
     end
   end
 


### PR DESCRIPTION
The new `invitation_usages` table can be used to track usage count now.