### PR TITLE
Ignore result when no table comment version exists

### DIFF
--- a/lib/usher/migration.ex
+++ b/lib/usher/migration.ex
@@ -120,7 +120,7 @@ defmodule Usher.Migration do
       {:ok, %{rows: [[version]]}} when is_binary(version) ->
         version_string_to_integer(version)
 
-      {:ok, %{rows: []}} ->
+      {:ok, %{rows: _}} ->
         check_legacy_table(prefix)
     end
   end


### PR DESCRIPTION
We want it fallthrough and check for legacy table.

The changed line will error for new installations otherwise.